### PR TITLE
Improve auth compatibility for frontend integration

### DIFF
--- a/src/routes/user.routes.js
+++ b/src/routes/user.routes.js
@@ -1,13 +1,14 @@
-const express = require('express')
-const User = require('../controllers/user.controller');
-
+const express = require("express");
+const User = require("../controllers/user.controller");
+const { authRequired } = require("../middleware/authRequired");
 
 const router = express.Router();
 
 router.get("/users", User.getAllUser);
+router.get("/users/me", authRequired, User.getUserById);
 router.get("/user/:id", User.getUserId);
-router.post("/user",  User.createUser);
-router.delete("/user/:id",  User.deleteUser);
-router.put("/user/:id",  User.updateUser);
+router.post("/user", authRequired, User.createUser);
+router.delete("/user/:id", authRequired, User.deleteUser);
+router.put("/user/:id", authRequired, User.updateUser);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- sanitize user payloads, add an authenticated `/users/me` endpoint, and guard write operations with auth middleware
- relax CORS handling so new frontend origins can be configured via the `CORS_ORIGINS` environment variable
- update background token attachment middleware to understand the new cookie/secret naming used by the frontend

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3143dce548321ac1b4d05d206361e