### PR TITLE
Support Titan service requests using full URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ Los endpoints Titans realizan las peticiones a los equipos Titans desde el backe
 curl "http://localhost:3000/api/v2/titans/services?host=172.19.14.118&path=/api/v1/servicesmngt/services"
 ```
 
+También puedes proporcionar la URL completa del Titan (incluyendo protocolo) mediante el parámetro `url`:
+
+```bash
+curl "http://localhost:3000/api/v2/titans/services?url=http://172.19.14.118/api/v1/servicesmngt/services"
+```
+
 ### Obtener servicios de múltiples hosts
 
 ```bash


### PR DESCRIPTION
## Summary
- allow the Titans controller to parse a full Titan URL and reuse its protocol, host, and path
- document the new `url` query parameter option for the Titans service endpoint

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e325e807ec83218bc801c9c209059e