### PR TITLE
Add support for building MongoDB URIs from env fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,16 @@ Crea un archivo `.env` en la raíz del backend (ya existe un ejemplo con valores
 
 ```bash
 PORT=3000
+# Puedes entregar una URI lista...
 MONGODB_URI=mongodb://localhost:27017/signalTV
+# ...o bien definir los fragmentos para construirla automáticamente
+# MONGODB_HOST=localhost
+# MONGODB_PORT=27017
+# MONGODB_DATABASE=signalTV
+# MONGODB_USERNAME=
+# MONGODB_PASSWORD=
+# MONGODB_AUTH_SOURCE=admin
+# MONGODB_OPTIONS=retryWrites=true&w=majority
 TITAN_USERNAME=Operator
 TITAN_PASSWORD=titan
 TITAN_DEFAULT_PROTOCOL=http
@@ -31,6 +40,10 @@ npm run dev # nodemon
 # o
 npm start
 ```
+
+El backend intentará construir la cadena de conexión usando `MONGODB_URI` o, si no está disponible,
+los fragmentos `MONGODB_HOST`, `MONGODB_DATABASE`, etc. La cadena que se usa se muestra (sin credenciales)
+en la consola para facilitar la depuración.
 
 El servidor sólo comienza a escuchar una vez que la conexión a MongoDB se establece correctamente.
 
@@ -59,6 +72,12 @@ Los endpoints Titans realizan las peticiones a los equipos Titans desde el backe
 
 ```bash
 curl "http://localhost:3000/api/v2/titans/services?host=172.19.14.118&path=/api/v1/servicesmngt/services"
+```
+
+También puedes proporcionar la URL completa del Titan (incluyendo protocolo) mediante el parámetro `url`:
+
+```bash
+curl "http://localhost:3000/api/v2/titans/services?url=http://172.19.14.118/api/v1/servicesmngt/services"
 ```
 
 ### Obtener servicios de múltiples hosts

--- a/src/config/config.mongoose.js
+++ b/src/config/config.mongoose.js
@@ -6,13 +6,110 @@ const {
   MONGOOSE_DEBUG,
 } = process.env;
 
-const DEFAULT_URI = MONGODB_URI || MONGO_URI;
+const FALLBACK_URI = buildUriFromFragments();
+const DEFAULT_URI = MONGODB_URI || MONGO_URI || FALLBACK_URI;
 const CONNECTION_TIMEOUT_MS = Number(process.env.MONGODB_TIMEOUT_MS || 5000);
 const FAMILY = process.env.MONGODB_FAMILY
   ? Number(process.env.MONGODB_FAMILY)
   : 4;
 
 let connectionPromise = null;
+
+function buildUriFromFragments() {
+  const protocol = normalizeProtocol(
+    process.env.MONGODB_PROTOCOL || process.env.MONGO_PROTOCOL
+  );
+  const host = process.env.MONGODB_HOST || process.env.MONGO_HOST;
+  const port = process.env.MONGODB_PORT || process.env.MONGO_PORT;
+  const database =
+    process.env.MONGODB_DATABASE ||
+    process.env.MONGODB_DB ||
+    process.env.MONGO_DATABASE ||
+    process.env.MONGO_DB;
+
+  if (!host || !database) {
+    return null;
+  }
+
+  const username =
+    process.env.MONGODB_USERNAME ||
+    process.env.MONGO_USERNAME ||
+    process.env.MONGO_USER;
+  const password =
+    process.env.MONGODB_PASSWORD ||
+    process.env.MONGO_PASSWORD ||
+    process.env.MONGO_PASS;
+
+  const query = buildQueryString();
+
+  const credentials =
+    username !== undefined && username !== ""
+      ? `${encodeURIComponent(username)}:${encodeURIComponent(password || "")}`
+      : null;
+
+  const authority = credentials
+    ? `${credentials}@${host}${port ? `:${port}` : ""}`
+    : `${host}${port ? `:${port}` : ""}`;
+
+  return `${protocol}://${authority}/${database}${query}`;
+}
+
+function normalizeProtocol(rawProtocol) {
+  if (!rawProtocol) {
+    return "mongodb";
+  }
+
+  const protocol = String(rawProtocol).trim().toLowerCase().replace(/:$/, "");
+  if (!protocol) {
+    return "mongodb";
+  }
+
+  return protocol;
+}
+
+function buildQueryString() {
+  const parts = [];
+
+  const rawOptions = process.env.MONGODB_OPTIONS || process.env.MONGO_OPTIONS;
+  if (rawOptions) {
+    const normalized = String(rawOptions).replace(/^\?/, "");
+    if (normalized) {
+      normalized
+        .split("&")
+        .map((value) => value.trim())
+        .filter(Boolean)
+        .forEach((value) => parts.push(value));
+    }
+  }
+
+  const authSource =
+    process.env.MONGODB_AUTH_SOURCE || process.env.MONGO_AUTH_SOURCE;
+  if (authSource) {
+    parts.push(`authSource=${encodeURIComponent(authSource)}`);
+  }
+
+  if (!parts.length) {
+    return "";
+  }
+
+  return `?${parts.join("&")}`;
+}
+
+function sanitizeConnectionString(uri) {
+  if (!uri) return uri;
+
+  try {
+    const parsed = new URL(uri);
+    if (parsed.username || parsed.password) {
+      parsed.username = parsed.username ? "***" : "";
+      parsed.password = parsed.password ? "***" : "";
+      return parsed.toString();
+    }
+    return uri;
+  } catch (_error) {
+    return uri;
+  }
+}
 
 function connectMongoose() {
   if (!DEFAULT_URI) {
@@ -28,6 +125,9 @@ function connectMongoose() {
   if (MONGOOSE_DEBUG === "true") {
     mongoose.set("debug", true);
   }
+
+  const maskedUri = sanitizeConnectionString(DEFAULT_URI);
+  console.log(`🔌 Connecting to MongoDB using ${maskedUri}`);
 
   connectionPromise = mongoose
     .connect(DEFAULT_URI, {


### PR DESCRIPTION
## Summary
- allow the MongoDB connection to fall back to a URI assembled from host/user/password environment fragments
- log the sanitized MongoDB connection string and document the new configuration options in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e325e807ec83218bc801c9c209059e