### PR TITLE
Restrict diagram editing to authenticated users and persist label positions

### DIFF
--- a/src/middleware/authRequired.js
+++ b/src/middleware/authRequired.js
@@ -10,7 +10,11 @@ function authRequired(req, res, next) {
 
     if (!token) {
       // No hay cookie -> no hay sesión
-      return res.status(401).json({ error: "no_token" });
+      return res.status(401).json({
+        error: "no_token",
+        message:
+          "Modo de solo lectura: inicia sesión para editar diagramas o etiquetas.",
+      });
     }
 
     // 2) Verificar firma y expiración
@@ -30,9 +34,17 @@ function authRequired(req, res, next) {
   } catch (err) {
     // Firmas/expiración
     if (err?.name === "TokenExpiredError") {
-      return res.status(401).json({ error: "token_expired" });
+      return res.status(401).json({
+        error: "token_expired",
+        message:
+          "La sesión expiró. Inicia sesión nuevamente para editar diagramas o etiquetas.",
+      });
     }
-    return res.status(401).json({ error: "invalid_token" });
+    return res.status(401).json({
+      error: "invalid_token",
+      message:
+        "No pudimos validar tu sesión. Inicia sesión para salir del modo de solo lectura.",
+    });
   }
 }
 

--- a/src/models/channel.model.js
+++ b/src/models/channel.model.js
@@ -1,6 +1,18 @@
 // server/models/channel.model.js
 const mongoose = require("mongoose");
 
+const NodeDataSchema = new mongoose.Schema(
+  {
+    label: { type: String, required: true },
+    image: String,
+    labelPosition: {
+      x: { type: Number },
+      y: { type: Number },
+    },
+  },
+  { _id: false, strict: false, minimize: false }
+);
+
 const NodeSchema = new mongoose.Schema({
   id: { type: String, required: true },
   type: { type: String, default: "image" },
@@ -13,10 +25,7 @@ const NodeSchema = new mongoose.Schema({
     x: { type: Number, required: true },
     y: { type: Number, required: true },
   },
-  data: {
-    label: { type: String, required: true },
-    image: String,
-  },
+  data: { type: NodeDataSchema, required: true },
 });
 
 const EdgeSchema = new mongoose.Schema({
@@ -31,6 +40,10 @@ const EdgeSchema = new mongoose.Schema({
   sourceHandle: String,
   targetHandle: String,
   label: String,
+  labelPosition: {
+    x: { type: Number },
+    y: { type: Number },
+  },
 
   // 👇 necesario para guardar multicast y otros campos del front
   data: { type: mongoose.Schema.Types.Mixed, default: {} },

--- a/src/models/nodo.model.js
+++ b/src/models/nodo.model.js
@@ -10,6 +10,10 @@ const NodeSchema = new mongoose.Schema(
     },
     data: {
       label: { type: String, required: true },
+      labelPosition: {
+        x: { type: Number },
+        y: { type: Number },
+      },
       otherData: { type: mongoose.Schema.Types.Mixed }, // otros datos opcionales
     },
   },


### PR DESCRIPTION
## Summary
- add explicit read-only messaging when authentication is missing or invalid
- extend channel and node schemas to store draggable label positions for diagrams

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3e486d7508321a8951e8f7c0ce6de